### PR TITLE
[2024-06-04] gwangseok #78

### DIFF
--- a/Programmers/혼자서 하는 틱택토/gwangseok.py
+++ b/Programmers/혼자서 하는 틱택토/gwangseok.py
@@ -4,14 +4,14 @@ def check_hit(board, r, c):
         vert = all([board[k][c] == board[r][c] for k in range(3)]) # 상하
         if c == 0:
             dig = all([board[k][k] == board[r][c] for k in range(3)]) # 대각선
-            return hori or vert or dig
+            return hori or vert or dig  # [0,0] 가로, 세로, 대각선 빙고 확인
         elif c == 1:
-            return vert
+            return vert # [0,1] 세로 빙고 확인
         elif c == 2:
             dig = all(board[k][2-k] == board[r][c] for k in range(3)) # 대각선
-            return vert or dig
+            return vert or dig # [0,2] 세로, 대각선 빙고 확인
     else:
-        return hori
+        return hori # [1,0] [2,0] 가로 빙고 확인
 
 
 def solution(board):
@@ -28,22 +28,34 @@ def solution(board):
         for c in range(3):
             nums[mark[board[r][c]]] += 1
             if board[r][c] != '.' and (r==0 or c==0):
-                tmp_hit = check_hit(board, r, c)
-                if is_hit and tmp_hit and win_mark != board[r][c]:
+                # 제일 윗줄: 가로, 세로, 대각선 빙고 확인 ([0,0] -> 가로 세로 대각선, [0,1] -> 세로, [0,2] -> 대각선, 세로)
+                # 2, 3번째 줄: 가로 빙고 확인 ([1,0] -> 가로, [2.0] -> 가로)
+                
+                tmp_hit = check_hit(board, r, c) # 현재 row, column에서 빙고 확인
+                if is_hit and tmp_hit and win_mark != board[r][c]: 
+                    # 이전에 빙고가 있고 (is_hit), 현재도 빙고가 있는데(tmp_hit), 빙고 마크가 다른 경우 False
+                    # 한번 놓을 때 빙고가 2번 되는 경우를 생각하는 데 오래 걸림
                     return 0
                 if tmp_hit and win_mark is None:
+                    # 현재 빙고 일 때, win_mark update
+                    # win_mark is None 없어도 됨.
                     win_mark = board[r][c]
-                
+
+                # 이전에 빙고 확인(is_hit True)이 되었다면, is_hit은 계속 True 유지
+                # 만약 이전에 빙고가 확인이 안 되었다면, 현재 빙고 상태로 is_hit update
                 is_hit = is_hit if is_hit else tmp_hit
                                     
     if not is_hit and 0 <= nums[0] - nums[1] < 2:
+        # 빙고가 없다면, O의 개수가 X보다 1개 많거나 같다.
         return 1
     else:
         if win_mark == 'O':
             if nums[0] - nums[1] == 1:
+                # O 빙고라면 O의 개수가 1개 더 많음.
                 return 1
         else:
             if nums[0] == nums[1]:
+                # X 빙고라면 O와 X의 개수가 같음.
                 return 1
     
     return 0

--- a/Programmers/혼자서 하는 틱택토/gwangseok.py
+++ b/Programmers/혼자서 하는 틱택토/gwangseok.py
@@ -1,0 +1,49 @@
+def check_hit(board, r, c):
+    hori = all([board[r][k] == board[r][c] for k in range(3)])  # 좌우
+    if r == 0:
+        vert = all([board[k][c] == board[r][c] for k in range(3)]) # 상하
+        if c == 0:
+            dig = all([board[k][k] == board[r][c] for k in range(3)]) # 대각선
+            return hori or vert or dig
+        elif c == 1:
+            return vert
+        elif c == 2:
+            dig = all(board[k][2-k] == board[r][c] for k in range(3)) # 대각선
+            return vert or dig
+    else:
+        return hori
+
+
+def solution(board):
+    win_mark = None
+    is_hit = False  
+    nums = [0, 0, 0]  # num_o, num_x, num_.
+    mark = {
+        'O': 0,
+        'X': 1,
+        '.': 2
+    }
+        
+    for r in range(3):
+        for c in range(3):
+            nums[mark[board[r][c]]] += 1
+            if board[r][c] != '.' and (r==0 or c==0):
+                tmp_hit = check_hit(board, r, c)
+                if is_hit and tmp_hit and win_mark != board[r][c]:
+                    return 0
+                if tmp_hit and win_mark is None:
+                    win_mark = board[r][c]
+                
+                is_hit = is_hit if is_hit else tmp_hit
+                                    
+    if not is_hit and 0 <= nums[0] - nums[1] < 2:
+        return 1
+    else:
+        if win_mark == 'O':
+            if nums[0] - nums[1] == 1:
+                return 1
+        else:
+            if nums[0] == nums[1]:
+                return 1
+    
+    return 0


### PR DESCRIPTION
### PR Summary

<풀이 시간>
1시간

<문제 회고>
문제를 보고 같은 row, column은 2번 방문하면 시간이 걸릴 것 같아 2중 for문으로 필요한 정보를 얻었다. 
그러다 보니 예외 처리를 해야 할 부분이 생겨서 오래 걸렸다.
다른 분들 코드를 여러번 방문하는 게 보기 깔끔하고 시간이 덜 걸린다.
[파이썬은 function call 비용이 비싸다는 것](https://brorica.tistory.com/139)을 알게 되었다.

- Global dict table에 많은 함수들의 정보가 있어 원하는 identitifer(함수)를 찾으려면 시간이 소모된다. O(log N)
- 파이썬 코드를 실행하기 위해선 내부적으로 많은 모듈들이 실행된다.
- 호출 횟수가 엄청 크지 않는 이상 성능 저하가 크지 않다. 
- 하지만, 코테에서 특정 기능을 빠르고 반복적으로 수행해야 할 경우 repeat 대신 iterable을 지향하자.
- 추가로 함수 호출이 느린 또 다른 이유 -> Monkey Patch: 런타임에 attribute를 동적으로 결정하것
- 즉, C나 JAVA처럼 컴파일 과정에서 매개변수를 실체화하는 것이 아니라 런타임에 추상적인 매개변수를 실체화하기 때문에 함수 호출 비용 증가.
- 내장 함수는 C로 되어 있기 때문에 더 빠르다.

all이나 any 함수를 사용할 때, generator를 활용하면 memory/time에서 더 효율적이다.
- all([a for a in b])보단 all(a for a in b)를 사용하자.


Case | Complexity
-- | --
테스트 1 〉 | 통과 (0.02ms, 10.4MB)
테스트 2 〉 | 통과 (0.02ms, 10.3MB)
테스트 3 〉 | 통과 (0.02ms, 10.2MB)
테스트 4 〉 | 통과 (0.03ms, 10.3MB)
테스트 5 〉 | 통과 (0.02ms, 10.1MB)
테스트 6 〉 | 통과 (0.02ms, 10.3MB)
테스트 7 〉 | 통과 (0.03ms, 10.2MB)
테스트 8 〉 | 통과 (0.02ms, 10.3MB)
테스트 9 〉 | 통과 (0.01ms, 10.4MB)
테스트 10 〉 | 통과 (0.01ms, 10.2MB)
테스트 11 〉 | 통과 (0.02ms, 10.3MB)
테스트 12 〉 | 통과 (0.03ms, 10.3MB)
테스트 13 〉 | 통과 (0.03ms, 10.2MB)
테스트 14 〉 | 통과 (0.02ms, 10.3MB)
테스트 15 〉 | 통과 (0.02ms, 10.4MB)
테스트 16 〉 | 통과 (0.02ms, 10.3MB)
테스트 17 〉 | 통과 (0.03ms, 10.4MB)
테스트 18 〉 | 통과 (0.02ms, 10.3MB)
테스트 19 〉 | 통과 (0.01ms, 10.3MB)
테스트 20 〉 | 통과 (0.02ms, 10.4MB)
테스트 21 〉 | 통과 (0.02ms, 10.2MB)
테스트 22 〉 | 통과 (0.03ms, 10.2MB)
테스트 23 〉 | 통과 (0.02ms, 10.2MB)
테스트 24 〉 | 통과 (0.01ms, 10.2MB)
테스트 25 〉 | 통과 (0.03ms, 10.2MB)
테스트 26 〉 | 통과 (0.03ms, 10.3MB)
테스트 27 〉 | 통과 (0.03ms, 10.3MB)
테스트 28 〉 | 통과 (0.02ms, 10.4MB)
테스트 29 〉 | 통과 (0.02ms, 10.2MB)
테스트 30 〉 | 통과 (0.04ms, 10.4MB)
테스트 31 〉 | 통과 (0.02ms, 10.3MB)
테스트 32 〉 | 통과 (0.02ms, 10.3MB)
테스트 33 〉 | 통과 (0.02ms, 10.3MB)
테스트 34 〉 | 통과 (0.02ms, 10.2MB)
테스트 35 〉 | 통과 (0.01ms, 10.2MB)
테스트 36 〉 | 통과 (0.04ms, 10.2MB)
테스트 37 〉 | 통과 (0.03ms, 10.2MB)
테스트 38 〉 | 통과 (0.03ms, 10.3MB)
테스트 39 〉 | 통과 (0.02ms, 10.3MB)
테스트 40 〉 | 통과 (0.02ms, 10.2MB)
테스트 41 〉 | 통과 (0.02ms, 10.3MB)
테스트 42 〉 | 통과 (0.02ms, 10.2MB)
테스트 43 〉 | 통과 (0.02ms, 10.2MB)
테스트 44 〉 | 통과 (0.03ms, 10.2MB)
테스트 45 〉 | 통과 (0.02ms, 10.3MB)
테스트 46 〉 | 통과 (0.02ms, 10.2MB)
테스트 47 〉 | 통과 (0.02ms, 10.2MB)
테스트 48 〉 | 통과 (0.02ms, 10.4MB)
테스트 49 〉 | 통과 (0.02ms, 10.2MB)
테스트 50 〉 | 통과 (0.02ms, 10.2MB)
테스트 51 〉 | 통과 (0.01ms, 10.2MB)
테스트 52 〉 | 통과 (0.01ms, 10.2MB)
테스트 53 〉 | 통과 (0.02ms, 10.3MB)
테스트 54 〉 | 통과 (0.02ms, 10.3MB)



### ISSUE NUMBER
<!-- 이슈 번호를 입력해주세요 -->
- #78 