### PR TITLE
[2024-06-06] gwangseok #84

### DIFF
--- a/Programmers/표현 가능한 이진트리/gwangseok.py
+++ b/Programmers/표현 가능한 이진트리/gwangseok.py
@@ -1,8 +1,8 @@
 # 시간 복잡도
-# tree_depth: O(log(50)) -> O(1), 1e50의 이진수 length = 50  // 최대 depth: 6
-# is_all_zero: O(2*6 - 1) -> O(1), 더미를 포함한 최대 길이 = 63
-# is_root: O(63 + 2 * is_all_zero) -> O(1), 최대 길이 63이고 root만 확인 + 0일 때 좌, 우 child 확인
-# 결국 O(N)
+# tree_depth: O(int(log(int(log(M)) + 1))) -> O(log(log M)) // 1e15의 이진수 length = 50  // 최대 depth: 6
+# is_all_zero: O(2*int(log(log(M) + 1)) - 1) -> O(log M) // 더미를 포함한 최대 길이 = 63
+# is_root: O(3 * is_all_zero) -> O(log M) // 최대 길이 2*int(log(log(M) + 1)) - 1이고 root만 확인 그리고 0일 때 좌, 우 child 확인
+# 결국 O(N * log M)
 
 
 def tree_depth(length: int) -> int:

--- a/Programmers/표현 가능한 이진트리/gwangseok.py
+++ b/Programmers/표현 가능한 이진트리/gwangseok.py
@@ -1,0 +1,61 @@
+# 시간 복잡도
+# tree_depth: O(log(50)) -> O(1), 1e50의 이진수 length = 50  // 최대 depth: 6
+# is_all_zero: O(2*6 - 1) -> O(1), 더미를 포함한 최대 길이 = 63
+# is_root: O(63 + 2 * is_all_zero) -> O(1), 최대 길이 63이고 root만 확인 + 0일 때 좌, 우 child 확인
+# 결국 O(N)
+
+
+def tree_depth(length: int) -> int:
+    # 이진수를 표현하기 위한 최소한의 tree depth를 구한다.
+    # int(log_2(length)) + 1
+    depth = 0
+    while length > 0:
+        length //= 2
+        depth += 1
+        
+    return depth
+
+
+def is_all_zero(tmp_str: str) -> bool:
+    # 현재 입력된 binary string이 모두 0인지 판단.
+    for c in tmp_str:
+        if c == '1':
+            return False
+    
+    return True
+
+
+def is_root_one(tmp_bin: str) -> int:
+    if len(tmp_bin) == 1:
+        # 자식 노드가 없다면 root는 0이 되든 1이 되든 상관 없이 True
+        return 1
+    
+    mid = len(tmp_bin) // 2  # root 노드가 될 index
+    left_str = tmp_bin[:mid]  # root 노드를 기준으로 좌측 child
+    right_str = tmp_bin[mid + 1:]  # root 노드를 기준으로 우측 child
+    if tmp_bin[mid] == '0':  # root가 0일 경우
+        if is_all_zero(left_str) and is_all_zero(right_str):
+            # 좌, 우 child가 모두 0이면 True
+            return 1
+        else:
+            # 모두 0이 아니면 False
+            return 0
+    
+    # 좌, 우를 계속 검사
+    # 좌, 우 모두 True여야 True 반환
+    return is_root_one(left_str) and is_root_one(right_str)
+
+
+def is_bin(num: int) -> int:
+    str_bin = bin(num)[2:]  # 수를 이진수로 변환
+    depth = tree_depth(len(str_bin))  # 이진수를 표현하기 tree depth -> 1e15: 6
+    max_length = 2 ** depth - 1  # 포화 이진트리로 표현되는 수의 length -> 1e15: 63
+    tree_bin = '0' * (max_length - len(str_bin)) + str_bin  # '0'을 더미로 넣어서 포화 이진트리로 표현
+    return is_root_one(tree_bin)
+
+
+def solution(numbers: list):
+    answer = []
+    for num in numbers:
+        answer.append(is_bin(num))
+    return answer


### PR DESCRIPTION
### PR Summary

<풀이시간>
30분

<문제 회고>
포화 이진 트리와 완전 이진 트리 차이점을 몰라서 검색을 해봤다.
포화 이진 트리에 대해 파악한 후, 루트 노드를 기준으로 search를 해야 겠다라고 생각했다.

1. 수를 이진수로 만든다.
2. 이진수를 포화 이진 트리로 표현하기 위한 트리의 depth를 계산한다 -> d = int($log_2$(binary_length)) + 1 // 1e15의 depth는 6
3. 포화 이진 트리로 표현되어야 하는 이진수의 length를 계산한다. -> $2^d$ - 1  // 1e15의 length는 63
4. 이진수 앞에 '0'을 추가해 포화 이진 트리로 표현되는, 더미가 추가된 이진수를 구한다.
4.1. 예를 들어, 13이면 binary length는 4이고 depth d는 3이 된다. 
4.2. 더미를 포함한 13의 binary length는 $2^d$ - 1인 7이된다. 즉, '0001101'이 되어야 한다.
5. 더미가 추가된 이진수를 tree의 루트(가운데)를 기준으로 분할정복을 활용해 가능한지 불가능하지 검사한다.
5.1. 예를 들어, 13의 경우 root는 3번째 index인 1이 된다.
5.2. 1을 기준으로 왼쪽, 오른쪽으로 나눈다. '000', '1', '101'
5.3. '000'에서 다시 root를 구한다. 1번째 index인 0이다. 
5.4. root가 0이므로 자식 노드가 없어야 한다. -> 좌,우가 모두 0인지 확인한다. 1이 하나라도 있으면 False 반환
5.5. 모두 0이므로 '000'에 대해선 True이다.
5.6. '101'에서 root를 구하면 1번째 index인 0이다.
5.7. root가 0인데 좌,우 자식 노드가 1로 존재하게 되므로 False 반환.
5.8. 13은 표현 불가능.

Case | Complexity
-- | --
테스트 1 〉 | 통과 (0.01ms, 10.3MB)
테스트 2 〉 | 통과 (0.03ms, 10.3MB)
테스트 3 〉 | 통과 (0.04ms, 10.3MB)
테스트 4 〉 | 통과 (0.25ms, 10.2MB)
테스트 5 〉 | 통과 (0.27ms, 10.2MB)
테스트 6 〉 | 통과 (0.50ms, 10.3MB)
테스트 7 〉 | 통과 (0.79ms, 10.2MB)
테스트 8 〉 | 통과 (0.40ms, 10.4MB)
테스트 9 〉 | 통과 (3.50ms, 10.3MB)
테스트 10 〉 | 통과 (52.80ms, 11.2MB)
테스트 11 〉 | 통과 (35.23ms, 11.4MB)
테스트 12 〉 | 통과 (36.89ms, 11.3MB)
테스트 13 〉 | 통과 (30.62ms, 11.2MB)
테스트 14 〉 | 통과 (33.06ms, 11MB)
테스트 15 〉 | 통과 (21.34ms, 10.7MB)
테스트 16 〉 | 통과 (51.61ms, 11.3MB)
테스트 17 〉 | 통과 (62.69ms, 11.2MB)
테스트 18 〉 | 통과 (49.97ms, 11.1MB)
테스트 19 〉 | 통과 (59.33ms, 11.1MB)
테스트 20 〉 | 통과 (32.74ms, 10.7MB)

</pre><!--EndFragment-->
</body>
</html>