### PR TITLE
[2024-06-18] yerin #97

### DIFF
--- a/Programmers/호텔 대실/yerin.py
+++ b/Programmers/호텔 대실/yerin.py
@@ -1,0 +1,45 @@
+'''
+<문제 내용>
+최소한의 객실
+다음 이용 가능 시간 = 이전 퇴실 시간 + 10분
+
+book_time : [입실 시각, 퇴실 시각]
+시간 : HH:MM (24시간 표기법 - 00:00 ~ 23:59)
+
+퇴실 시각이 다른 예약 입실 시각 이전.
+입실 시각이 다른 예약 퇴실 시각 이후.
+
+<반환>
+필요한 최소 객실 수
+'''
+
+def solution(book_time: list):
+    # 입실 시간이 빠른 순서로 정렬
+    book_time.sort()
+    # key: 방번호, value: 다음 이용가능 시간(이전 예약 퇴실 시간 + 10분)
+    room = {}
+    new_room = 0
+
+    for check_in, check_out in book_time:
+        check_in_hour, check_in_min = map(int, check_in.split(":"))
+        check_out_hour, check_out_min = map(int, check_out.split(":"))
+        # 분 단위로 맞춤
+        check_in_time = check_in_hour * 60 + check_in_min
+        next_available_time = check_out_hour * 60 + check_out_min + 10
+
+        # 첫 예약일 때
+        if len(room.keys()) == 0:
+            room[new_room] = next_available_time
+            new_room += 1
+            continue
+        # 현재 쓰고 있는 방들 value 기준으로 정렬(오름차순). num : 방 번호, earlier_time : 가장 빠른 퇴실 시간
+        num, earlier_time = sorted(room.items(), key=lambda x:x[1])[0]
+        # 기존 방을 이어 쓰는 경우 (체크인 전, 이전 타임이 퇴실 가능한 경우)
+        if earlier_time <= check_in_time:
+            room[num] = next_available_time
+        # 새로운 방 배정
+        else:
+            room[new_room] = next_available_time
+            new_room += 1 # 새로운 방 번호 업데이트
+
+    return len(room.keys())


### PR DESCRIPTION
### PR Summary
<풀이 시간>
30분

<문제 회고>
입실 시간이 퇴실 시간 보다 항상 빠르다는 조건과 자정을 넘어가지 않는다는 조건이 있어 시간 비교만 하면 되겠다고 생각했다. 예약 시간들을 분 단위로 맞추어 계산 용이하도록 했다. 딕셔너리에 방 번호를 키로, 현 이용객의 퇴실 시간 + 10분을 값으로 하여 다음 이용시간을 확인할 수 있도록 했다.
로직은 크게 아래와 같이 정리할 수 있다.
- 다음 이용 가능 시간보다 체크인 시간이 빠른 경우, 새로운 방 부여
- 체크인 이전에 퇴실한 방이 있으면 해당 방 부여

datetime으로도 풀어보려고 했으나 time함수 사용여부에 따라 결과가 달라졌다. time()을 쓰면 실패로 뜨는데 이유를 아직 못찾았다.
<time() 사용 --> 실패>
```
for check_in, check_out in book_time:
        check_in = datetime.strptime(check_in, "%H:%M").time()
        check_out = datetime.strptime(check_out, "%H:%M")
        next_available_time = (check_out + timedelta(minutes=10)).time() 
```

<time() 미사용 --> 성공>
```
for check_in, check_out in book_time:
        check_in = datetime.strptime(check_in, "%H:%M")
        check_out = datetime.strptime(check_out, "%H:%M")
        next_available_time = check_out + timedelta(minutes=10)
```

테스트 | 결과
-- | --
테스트 1 〉 | 통과 (0.06ms, 10.3MB)
테스트 2 〉 | 통과 (3.05ms, 10.2MB)
테스트 3 〉 | 통과 (36.98ms, 10.5MB)
테스트 4 〉 | 통과 (16.21ms, 10.3MB)
테스트 5 〉 | 통과 (0.04ms, 10.2MB)
테스트 6 〉 | 통과 (26.00ms, 10.5MB)
테스트 7 〉 | 통과 (52.58ms, 10.5MB)
테스트 8 〉 | 통과 (9.76ms, 10.2MB)
테스트 9 〉 | 통과 (2.67ms, 10.4MB)
테스트 10 〉 | 통과 (19.46ms, 10.6MB)
테스트 11 〉 | 통과 (50.21ms, 10.6MB)
테스트 12 〉 | 통과 (36.73ms, 10.4MB)
테스트 13 〉 | 통과 (1.41ms, 10.3MB)
테스트 14 〉 | 통과 (40.90ms, 10.4MB)
테스트 15 〉 | 통과 (33.65ms, 10.4MB)
테스트 16 〉 | 통과 (4.87ms, 10.4MB)
테스트 17 〉 | 통과 (45.87ms, 10.6MB)
테스트 18 〉 | 통과 (17.65ms, 10.5MB)
테스트 19 〉 | 통과 (55.04ms, 10.6MB)


