### PR TITLE
[2024-06-25] yerin #114

### DIFF
--- a/Programmers/무인도 여행/yerin.py
+++ b/Programmers/무인도 여행/yerin.py
@@ -1,0 +1,43 @@
+'''
+'x' : 바다
+숫자 : 식량
+'''
+
+from collections import defaultdict, deque
+
+
+def bfs(start_x, start_y, maps, group_id, visited, amount_per_island, island_grp):
+    directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+    queue = deque([(start_x, start_y)])
+    visited.add((start_x, start_y))  # 방문 처리
+    amount_per_island[group_id] = int(maps[start_x][start_y])  # maps 값이신 string이므로 int로 변환
+    island_grp[(start_x, start_y)] = group_id  # 시작 좌표에 섬 id 할당
+
+    while queue:
+        x, y = queue.popleft()
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < len(maps) and 0 <= ny < len(maps[0]) and maps[nx][ny] != "X" and (nx, ny) not in visited:
+                visited.add((nx, ny))
+                queue.append((nx, ny))
+                amount_per_island[group_id] += int(maps[nx][ny])  # 해당 좌표가 해당하는 섬(섬 id)에
+                island_grp[(nx, ny)] = group_id
+
+
+def solution(maps):
+    visited = set()
+    amount_per_island = defaultdict(int)  # 그룹(섬) 넘버 : 식량 양
+    island_grp = defaultdict(int)  # 좌표 : 그룹(섬) 넘버
+    group_id = 0
+
+    for i in range(len(maps)):
+        for j in range(len(maps[0])):
+            # 숫자를 값으로 가지고 있고 방문한 적이 없을 때. 방문한 적이 있다면 다른 섬인 경우.
+            if maps[i][j] != "X" and (i, j) not in visited:
+                bfs(i, j, maps, group_id, visited, amount_per_island, island_grp)
+                group_id += 1  # 다른 섬 id 갱
+
+    return sorted(amount_per_island.values()) if amount_per_island else [-1]
+
+
+print(solution(["X591X", "X1X5X", "X231X", "1XXX1"]))


### PR DESCRIPTION
### PR Summary
<풀이 시간>
30분

<문제 회고>
예전에 프로그래머스에서 풀었던 [시추 문제](https://school.programmers.co.kr/learn/courses/30/lessons/250136)와 유사해서 금방 풀이법을 생각했다. 근데 변수명을 오타내서 의도치않은 결과가 나와 시간 소모가 있었다. bfs로 문제를 풀 때 같은 실수를 반복하는데 주의해야겠다.

이전 문제들에서 성호님께서 그룹 넘버를 만들어 그룹 별로 데이터를 정리하셨던 것이 평소 문제 풀이를 떠올릴 때 도움이 될 것 같아 기억해두고 있었는데, 시추 문제와 이번 문제 모두 활용해 보았다. 그 외에도 bfs에서 이전에 중복 탐색으로 시간 초과가 났던 경험이 떠올라 해당 부분을 주의해서 코드를 짰다.
여러모로 지금까지 이 스터디에서 풀어왔던 문제들에서 배운 것들을 활용해 볼 수 있었던 문제였다.

테스트 케이스 | 결과
-- | --
테스트 1 〉 | 통과 (0.01ms, 10.4MB)
테스트 2 〉 | 통과 (0.04ms, 10.4MB)
테스트 3 〉 | 통과 (0.08ms, 10.3MB)
테스트 4 〉 | 통과 (0.87ms, 10.5MB)
테스트 5 〉 | 통과 (1.53ms, 10.4MB)
테스트 6 〉 | 통과 (4.41ms, 10.3MB)
테스트 7 〉 | 통과 (1.37ms, 10.3MB)
테스트 8 〉 | 통과 (7.95ms, 10.6MB)
테스트 9 〉 | 통과 (8.04ms, 10.6MB)
테스트 10 〉 | 통과 (5.86ms, 10.7MB)
테스트 11 〉 | 통과 (5.70ms, 10.7MB)
테스트 12 〉 | 통과 (9.83ms, 10.9MB)
테스트 13 〉 | 통과 (9.46ms, 10.8MB)
테스트 14 〉 | 통과 (16.27ms, 11.9MB)
테스트 15 〉 | 통과 (14.30ms, 11.9MB)
테스트 16 〉 | 통과 (32.55ms, 11.7MB)
테스트 17 〉 | 통과 (0.46ms, 10.4MB)
테스트 18 〉 | 통과 (17.43ms, 11.8MB)
테스트 19 〉 | 통과 (17.88ms, 11.9MB)
테스트 20 〉 | 통과 (0.56ms, 10.3MB)
테스트 21 〉 | 통과 (0.94ms, 10.3MB)
테스트 22 〉 | 통과 (0.14ms, 10.4MB)
테스트 23 〉 | 통과 (21.01ms, 12MB)
테스트 24 〉 | 통과 (20.08ms, 11MB)
테스트 25 〉 | 통과 (0.25ms, 10.3MB)

