### PR TITLE
[2024-07-04] yerin #136

### DIFF
--- a/Programmers/숫자 타자 대회/yerin.py
+++ b/Programmers/숫자 타자 대회/yerin.py
@@ -115,3 +115,64 @@ def solution(numbers):
 # print(solution("3692581470"))
 # print(solution("7531"))
 print(solution("12345"))
+
+
+
+# from collections import deque, defaultdict
+
+
+# def solution(numbers):
+#     pos = {
+#         '1': (0, 0), '2': (0, 1), '3': (0, 2),
+#         '4': (1, 0), '5': (1, 1), '6': (1, 2),
+#         '7': (2, 0), '8': (2, 1), '9': (2, 2),
+#         '*': (3, 0), '0': (3, 1), '#': (3, 2)
+#     }
+#
+#     test = defaultdict(int)
+#     for i in range(4):
+#         for j in range(3):
+#             for num in range(10):
+#                 test[(i, j), pos[str(num)]] = cost((i, j), pos[str(num)])
+#
+#     l_pos = pos['4']
+#     r_pos = pos['6']
+#     first_num_pos = pos[numbers[0]]
+#
+#     q = deque([
+#         (0, first_num_pos, r_pos, test[(l_pos, first_num_pos)]),
+#         (0, l_pos, first_num_pos, test[(r_pos, first_num_pos)])
+#     ])
+#
+#     dist_list = [[] for _ in range(len(numbers))]
+#     dist_list[0].extend([
+#         test[(l_pos, first_num_pos)],
+#         test[(r_pos, first_num_pos)]
+#     ])
+#
+#     for i in range(1, len(numbers)):
+#         num = numbers[i]
+#         num_pos = pos[num]
+#
+#         while q and q[0][0] == i - 1:
+#             n, left, right, dist = q.popleft()
+#
+#             if left == right:
+#                 continue
+#
+#             if num_pos == right:
+#                 q.append((i, left, num_pos, dist + 1))
+#                 dist_list[i].append(dist + 1)
+#             elif num_pos == left:
+#                 q.append((i, num_pos, right, dist + 1))
+#                 dist_list[i].append(dist + 1)
+#             elif num_pos != right and num_pos != left:
+#                 new_dist_from_l = dist + test[(left, num_pos)]
+#                 new_dist_from_r = dist + test[(right, num_pos)]
+#
+#                 q.append((i, num_pos, right, new_dist_from_l))
+#                 q.append((i, left, num_pos, new_dist_from_r))
+#
+#                 dist_list[i].extend([new_dist_from_l, new_dist_from_r])
+#
+#     return min(dist_list[-1])

--- a/Programmers/숫자 타자 대회/yerin.py
+++ b/Programmers/숫자 타자 대회/yerin.py
@@ -45,7 +45,7 @@ def measure_distance(start, end):
                 else:
                     q.append(((nx, ny), dist + 2))
 
-# 경로 계산
+# 가중치 계산
 def cost(start, end):
     sx, sy = start
     ex, ey = end

--- a/Programmers/숫자 타자 대회/yerin.py
+++ b/Programmers/숫자 타자 대회/yerin.py
@@ -1,0 +1,121 @@
+'''
+숫자로만 이루어진 문자열
+민희 : 두 엄지 손가락
+[4, 6]
+
+가중치
+- 제자리 : 1
+- 상하좌우 : 2
+- 대각선 : 3
+- 그 외: 경로별 가중치 합 최소
+
+양손 동일한 숫자 위에 있을 수 없음
+'''
+from collections import deque, defaultdict
+
+
+# 상하좌우, 대각선, 동일한 위치에 있는 경우가 아닌 경우, 최소 거리를 구해주는 함수
+def measure_distance(start, end):
+    n, m = 4, 3
+    q = deque([(start, 0)])
+    diagonal = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
+    visited = set()
+    ex, ey = end
+
+    while q:
+        (x, y), dist = q.popleft()
+
+        if (x, y) == (ex, ey):
+            return dist
+
+        # 탐색하는 경로 줄이기
+        if x == ex:  # 목표 지점이 현재 위치와 같은 행
+            directions = [(0, 1), (0, -1)]
+        elif x < ex:  # 목표 지점이 현재 위치보다 아래에 있을 때
+            directions = [(1, 0), (1, 1), (1, -1)]
+        else:  # 목표 지점이 현재 위치보다 위에 있을 때
+            directions = [(-1, 0), (-1, 1), (-1, -1)]
+
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < n and 0 <= ny < m and (nx, ny) not in visited:
+                visited.add((nx, ny))
+                if (dx, dy) in diagonal:
+                    q.append(((nx, ny), dist + 3))
+                else:
+                    q.append(((nx, ny), dist + 2))
+
+# 경로 계산
+def cost(start, end):
+    sx, sy = start
+    ex, ey = end
+
+    if start == end:  # 동일
+        return 1
+    elif abs(sx - ex) + abs(sy - ey) == 1:  # 상하좌우
+        return 2
+    elif abs(sx - ex) == 1 and abs(sy - ey) == 1:  # 대각선
+        return 3
+    else:  # 그 외
+        return measure_distance(start, end)
+
+
+def solution(numbers):
+    # 숫자판 위치 설정
+    pos = {
+        '1': (0, 0), '2': (0, 1), '3': (0, 2),
+        '4': (1, 0), '5': (1, 1), '6': (1, 2),
+        '7': (2, 0), '8': (2, 1), '9': (2, 2),
+        '*': (3, 0), '0': (3, 1), '#': (3, 2)
+    }
+
+    # 모든 경로에 대한 거리값 미리 구해놓음
+    dist = defaultdict(int)
+    for i in range(4):
+        for j in range(3):
+            for num in range(10):
+                dist[(i, j), pos[str(num)]] = cost((i, j), pos[str(num)])
+
+    left = pos['4']
+    right = pos['6']
+    dp = {(left, right): 0}  # (왼손 좌표, 오른손 좌표, 누적 거리)
+
+    for num in numbers:
+        num_pos = pos[num]
+        new_dp = {}  # 다음 숫자로 넘어갈 때마다 dp를 갱신하기 위한 변수
+
+        for (l_pos, r_pos), cur_dist in dp.items():
+            if l_pos == r_pos:  # 왼손 오른손 겹치는 경우 제외
+                continue
+
+            if l_pos == num_pos:  # 숫자의 좌표와 왼손 위치 동일
+                new_dp[(num_pos, r_pos)] = cur_dist + 1
+            elif r_pos == num_pos:  # 숫자의 좌표와 오른손 위치 동일
+                new_dp[(l_pos, num_pos)] = cur_dist + 1
+            else:  # 왼손, 오른손, 숫자 모두 다른 좌표
+                # 이미 new_dp에 있는 경우, 출발지에 따라 거리값이 다를 수 있으니 최솟값으로 갱신
+                # 왼손이 이동
+                if (num_pos, r_pos) in new_dp and new_dp[(num_pos, r_pos)] < cur_dist + dist[(l_pos, num_pos)]:
+                    pass
+                else:
+                    new_dp[(num_pos, r_pos)] = cur_dist + dist[(l_pos, num_pos)]
+                # 오른손이 이동
+                if (l_pos, num_pos) in new_dp and new_dp[(l_pos, num_pos)] < cur_dist + dist[(r_pos, num_pos)]:
+                    pass
+                else:
+                    new_dp[(l_pos, num_pos)] = cur_dist + dist[(r_pos, num_pos)]
+        dp = new_dp
+    return min(dp.values())
+
+# print(solution('4'))
+# print(solution('6'))
+# print(solution('46'))
+# print(solution('4666666'))
+# print(solution("1756"))
+# print(solution("5123"))
+# print(solution('1111'))
+# print(solution('486'))
+# print(solution("2580"))
+# print(solution("3692581470"))
+# print(solution("7531"))
+print(solution("12345"))

--- a/Programmers/숫자 타자 대회/yerin.py
+++ b/Programmers/숫자 타자 대회/yerin.py
@@ -88,22 +88,18 @@ def solution(numbers):
             if l_pos == r_pos:  # 왼손 오른손 겹치는 경우 제외
                 continue
 
-            if l_pos == num_pos:  # 숫자의 좌표와 왼손 위치 동일
-                new_dp[(num_pos, r_pos)] = cur_dist + 1
-            elif r_pos == num_pos:  # 숫자의 좌표와 오른손 위치 동일
-                new_dp[(l_pos, num_pos)] = cur_dist + 1
-            else:  # 왼손, 오른손, 숫자 모두 다른 좌표
-                # 이미 new_dp에 있는 경우, 출발지에 따라 거리값이 다를 수 있으니 최솟값으로 갱신
-                # 왼손이 이동
-                if (num_pos, r_pos) in new_dp and new_dp[(num_pos, r_pos)] < cur_dist + dist[(l_pos, num_pos)]:
-                    pass
-                else:
-                    new_dp[(num_pos, r_pos)] = cur_dist + dist[(l_pos, num_pos)]
-                # 오른손이 이동
-                if (l_pos, num_pos) in new_dp and new_dp[(l_pos, num_pos)] < cur_dist + dist[(r_pos, num_pos)]:
-                    pass
-                else:
-                    new_dp[(l_pos, num_pos)] = cur_dist + dist[(r_pos, num_pos)]
+            # 이미 new_dp에 있는 경우, 출발지에 따라 거리값이 다를 수 있으니 최솟값으로 갱신
+            # 왼손이 이동
+            if (num_pos, r_pos) in new_dp and new_dp[(num_pos, r_pos)] < cur_dist + dist[(l_pos, num_pos)]:
+                pass
+            else:
+                new_dp[(num_pos, r_pos)] = cur_dist + dist[(l_pos, num_pos)]
+            # 오른손이 이동
+            if (l_pos, num_pos) in new_dp and new_dp[(l_pos, num_pos)] < cur_dist + dist[(r_pos, num_pos)]:
+                pass
+            else:
+                new_dp[(l_pos, num_pos)] = cur_dist + dist[(r_pos, num_pos)]
+
         dp = new_dp
     return min(dp.values())
 


### PR DESCRIPTION
### PR Summary
처음에는 시간 초과로 머리를 싸맸다. deque를 활용해서 숫자별 거리값들을 이차원 리스트에 저장을 했었다. 리스트가 커질수록 계산량이 많아지기 때문에 시간 초과가 난 것이라 생각하여(명확한 근거x. 좀 더 공부가 필요) 숫자별 거리값을 모두 저장하는 게 아니라 마지막 숫자를 제외하고 나머지는 갱신 후 삭제가 되도록 만들고자 했다. 그리고 숫자 좌표로 이동 후 (왼손, 오른손) 좌표가 같으나 거리값은 다른 경우 최솟값으로 저장하게 하고 싶은데 리스트에서는 방법이 떠오르지 않아 딕셔너리로 변경했다. (당시 데이터 구조를 '왼손, 오른손, 누적거리'로 구상했었다)

이후에는 반례를 찾느라 시간을 다썼다. 이전 코드(가장 먼저 커밋한 코드가 통과 못한 코드)를 보면, 숫자 좌표와 왼손이나 오른손 좌표가 같은 위치에 있는 경우를 따로 조건식을 두어 거리값을 갱신했었다. 그런 경우, 가중치가 1이니 당연히 최소 거리겠지 싶어 그렇게 작성을 했던 것인데 이전 거리값에 따라 1만 더하는 경우여도 최소가 아닐 수 있다는 걸 뒤늦게 생각해냈다.
사실 거리값을 구하는 함수에서 가중치 1인 경우도 반환해주기 때문에 조건식을 뺄 필요도 없었던 건데 케이스를 나누다 오히려 내가 함정을 만들어 버린 꼴이 되었다.

테스트 | 결과
-- | --
테스트 1 〉 | 통과 (0.45ms, 10.3MB)
테스트 2 〉 | 통과 (0.47ms, 10.4MB)
테스트 3 〉 | 통과 (0.48ms, 10.4MB)
테스트 4 〉 | 통과 (0.48ms, 10.3MB)
테스트 5 〉 | 통과 (0.49ms, 10.3MB)
테스트 6 〉 | 통과 (0.47ms, 10.5MB)
테스트 7 〉 | 통과 (0.47ms, 10.4MB)
테스트 8 〉 | 통과 (0.50ms, 10.2MB)
테스트 9 〉 | 통과 (0.49ms, 10.3MB)
테스트 10 〉 | 통과 (0.59ms, 10.3MB)
테스트 11 〉 | 통과 (0.65ms, 10.3MB)
테스트 12 〉 | 통과 (0.60ms, 10.5MB)
테스트 13 〉 | 통과 (0.65ms, 10.4MB)
테스트 14 〉 | 통과 (0.71ms, 10.2MB)
테스트 15 〉 | 통과 (0.60ms, 10.2MB)
테스트 16 〉 | 통과 (323.69ms, 10.3MB)
테스트 17 〉 | 통과 (501.67ms, 10.4MB)
테스트 18 〉 | 통과 (706.36ms, 10.3MB)
테스트 19 〉 | 통과 (1043.82ms, 10.4MB)
테스트 20 〉 | 통과 (1386.42ms, 10.4MB)

