### PR TITLE
[2024-07-11] yerin #143

### DIFF
--- a/Programmers/등대/yerin.py
+++ b/Programmers/등대/yerin.py
@@ -1,0 +1,39 @@
+from collections import defaultdict
+
+
+def solution(n, lighthouse):
+    lh_dict = defaultdict(list)
+    for a, b in lighthouse:
+        lh_dict[a].append(b)
+        lh_dict[b].append(a)
+
+    # print(lh_dict)
+    stack = [(1, False)]  # (node, is_returning). 1번을 시작값으로 설정
+    parent = [-1] * (n + 1)  # 부모 노드 저장
+    visited = [False] * (n + 1)
+    dp = [[0, 0] for _ in range(n + 1)]  # dp[node] = [min_on, min_off]
+
+    while stack:
+        node, is_returning = stack.pop()
+
+        if not is_returning:  # 처음 방문하는 경우
+            visited[node] = True
+            stack.append((node, True))  # 방문 여부를 True로 하여 스택에 새로 삽입
+            for n in lh_dict[node]:
+                if not visited[n]:  # 방문한 적이 없는 자식 노드를 스택에 삽입
+                    parent[n] = node  # 현 노드를 부모 노드로 설정 (node: 현 노드, n: 자식 노드)
+                    stack.append((n, False))  # 자식 노드 스택에 삽입
+
+        else:  # 처음 방문 후, 되돌아 온 경우
+            on, off = 1, 0
+            for n in lh_dict[node]:  # n: 자식 노드, node: 현 노드
+                if n != parent[node]:  # 연결된 노드 중, 현 노드의 부모인 경우 제외. 자식 노드인 경우만 확인
+                    on += min(dp[n][0], dp[n][1])  # 현 노드가 켜진 상태. 자식 노드가 켜지거나 꺼진 경우 중 최솟값을 더함
+                    off += dp[n][0]  # 현 노드가 꺼진 경우. 자식 노드가 무조건 켜진 상태여야 함.
+            dp[node][0], dp[node][1] = on, off  # 0번 인덱스 : on, 1번 인덱스 : off
+
+    return min(dp[1][0], dp[1][1])
+
+print(solution(	8, [[1, 2], [1, 3], [1, 4], [1, 5], [5, 6], [5, 7], [5, 8]]))
+print("-----")
+print(solution(10, [[4, 1], [5, 1], [5, 6], [7, 6], [1, 2], [1, 3], [6, 8], [2, 9], [9, 10]]))


### PR DESCRIPTION
### PR Summary
등대의 개수(n)의 범위가 10만 이하여서 완전 탐색으로 풀어봐야겠다는 생각을 했다. 그런데 코드 구현 방법을 떠올리지 못했다. [힌트를](https://www.ai-bio.info/programmers/133500) 찾아보니 on, off 값을 저장해서 비교하는 방식을 취하고 있었다.

힌트에서는 재귀를 활용했는데 깊이 제한을 건들이지 않고 stack으로 풀어보고자 했다. 수민님이 저번에 스택으로 dfs를 구현하셨던 걸 참고하기도 했다. 그 과정에서 아직 스택을 어떤 식으로 활용할 수 있을지 고민하고 공부할 필요가 있다고 느꼈다.

전반적으로 dp와 스택을 더 공부해보면 좋을 것 같다는 생각이 드는 시간이었다.

테스트 | 결과
-- | --
테스트 1 〉 | 통과 (372.81ms, 50.2MB)
테스트 2 〉 | 통과 (425.14ms, 50.4MB)
테스트 3 〉 | 통과 (346.36ms, 49.9MB)
테스트 4 〉 | 통과 (373.25ms, 50.1MB)
테스트 5 〉 | 통과 (358.49ms, 50MB)
테스트 6 〉 | 통과 (288.78ms, 51MB)
테스트 7 〉 | 통과 (328.66ms, 51.2MB)
테스트 8 〉 | 통과 (286.42ms, 50.2MB)
테스트 9 〉 | 통과 (241.50ms, 51.1MB)
테스트 10 〉 | 통과 (312.96ms, 49.9MB)
테스트 11 〉 | 통과 (109.22ms, 29.8MB)
테스트 12 〉 | 통과 (59.58ms, 21.3MB)
테스트 13 〉 | 통과 (29.47ms, 13.7MB)
테스트 14 〉 | 통과 (0.01ms, 10.3MB)
테스트 15 〉 | 통과 (1.59ms, 10.5MB)
테스트 16 〉 | 통과 (14.01ms, 11.8MB)

