### PR TITLE
[2024-07-11] sumin #143

### DIFF
--- a/Programmers/등대/sumin.py
+++ b/Programmers/등대/sumin.py
@@ -1,0 +1,89 @@
+"""
+<문제>
+1~n까지 서로 다른 번호가 매겨진 등대 n개가 존재한다.
+뱃길은 n-1개 존재하며, 어느 등대에서 출발해도 다른 모든 등대까지 이동할 수 있다.
+한 뱃길의 양쪽 끝 등대 중 적어도 하나는 켜져있도록 등대를 켜두어야 한다.
+
+<제한 사항>
+- 2 ≤ n ≤ 100,000
+- lighthouse의 길이 = n – 1
+- lighthouse 배열의 각 행 [a, b]는 a번 등대와 b번 등대가 뱃길로 연결되어 있다는 의미
+- 1 ≤ a ≠ b ≤ n
+- 모든 등대는 서로 다른 등대로 이동할 수 있는 뱃길이 존재하도록 입력이 주어진다.
+
+<풀이 시간>
+2시간 이상
+
+<풀이>
+처음에는 리프노드를 찾고 모든 리프노드의 부모 노드를 켜주면 되는 그리디 문제라고 생각해 그리디로 풀이를 접근했다.
+예제로 다 통과하고, 다른 반례를 찾지 못해서 맞왜틀만 하다가, 결국 아이디어를 참고해서 DP로 풀이해야함을 알았다.
+1. DP 테이블 정의
+- dp[node][0]: node가 꺼져있을 때, node를 루트로 하는 서브트리에서 최소로 불이 켜진 개수
+- dp[node][1]: node가 켜져있을 때, node를 루트로 하는 서브트리에서 최소로 불이 켜진 개수
+
+2. 초기값 정의
+dp[node][0] = 0
+dp[node][1] = 1
+
+# 3. 점화식
+dp[node][0] += dp[child][1]
+- node가 꺼져있기 때문에 child가 켜져있어야 함
+dp[node][1] += min(dp[child][0], dp[child][1])
+- node가 켜져있을 때, child가 켜지거나 꺼지거나 더 작은 걸 선택
+
+<시간 복잡도>
+1. 그래프 정의: O(n)
+2. DFS 순회: O(n)
+3. DP 테이블 업데이트: O(n)
+-> O(n) + O(n) + O(n) = O(n)
+"""
+
+
+def dfs(node, parent, graph, dp):
+    dp[node][0] = 0 # 해당 노드에 불이 꺼져있을 때, node를 루트로 하는 서브트리에서 최소로 불이 켜진 개수
+    dp[node][1] = 1 # 해당 노드에 불이 켜져있을 때, node를 루트로 하는 서브트리에서 최소로 불이 켜진 개수
+
+    for child in graph[node]:
+        if child == parent:
+            continue
+        dfs(child, node, graph, dp)
+
+        dp[node][0] += dp[child][1] # 자식 노드들이 켜져있어야 하므로
+        dp[node][1] += min(dp[child][0], dp[child][1]) # 자식 노드들이 꺼져있거나 켜져있을 수 있으므로
+
+
+# def dfs_stack(start_node, graph, dp):
+#     stack = [(start_node, -1)]
+#     order = []
+#
+#     while stack:
+#         node, parent = stack.pop()
+#         order.append((node, parent))
+#         for child in graph[node]:
+#             if child != parent:
+#                 stack.append((child, node))
+#
+#     # 역순으로 순회하며 DP 업데이트
+#     while order:
+#         node, parent = order.pop()
+#         dp[node][0], dp[node][1] = 0, 1
+#         for child in graph[node]:
+#             if child != parent:
+#                 dp[node][0] += dp[child][1]
+#                 dp[node][1] += min(dp[child][0], dp[child][1])
+
+
+def solution(n: int, lighthouse: list) -> int:
+    tree = [[] for _ in range(n+1)]
+
+    for a, b in lighthouse:
+        tree[a].append(b)
+        tree[b].append(a)
+
+    # DP 테이블 정의
+    dp = [[0, 0] for _ in range(n+1)]
+
+    # dfs_stack(1, tree, dp)
+    dfs(1, -1, tree, dp)
+
+    return min(dp[1])


### PR DESCRIPTION
### PR Summary
<!-- PR 내용을 간략하게 소개해주세요 -->
<풀이 시간>
2시간 이상

<문제 회고>
처음에 그리디로 접근해서 풀이했다.
각 리프노드의 부모 노드를 모두 켜주는 식으로 진행하면 된다고 생각했고, 반례를 찾지 못했다.
결국에 [아이디어](https://school.programmers.co.kr/questions/74238)를 참고해서 DP로 접근해야 한다는 것을 확인했다.

동적 프로그래밍(DP) 접근법은 각 노드의 상태를 정의하고, 모든 가능한 선택을 고려하여 최적의 해를 계산할 수 있다. 
특히, DFS + DP를 사용하면 **각 노드가 켜져 있는 경우**와 **꺼져 있는 경우**를 모두 고려할 수 있기 때문에, 단순히 현재 단계에서 최적의 선택을 하는 그리디와 달리, 전체 트리 구조를 고려해 최적의 해를 보장할 수 있다.

반례 계속 못찾다가, n=8, lighthouse=[[1, 2], [2, 5], [1, 4], [4, 6], [1, 3], [3, 7], [7, 8]]
이 반례를 찾을 수 있었다. [여기](https://school.programmers.co.kr/questions/39676)에 누군가 아주 친절하게 그림까지 그려주셨는데, 내가 처음에 짠 그리디로 풀이하면 해당 결과를 3으로 반환하기 때문에 틀린 코드가 된다는 것을 확인할 수 있다.

+ 트리 순회의 경우 DFS를 재귀 방식과 스택 방식 모두 구현해서 제출해봤는데 재귀 방식이 약간 더 빠른 걸 확인할 수 있었다. (하지만, 여전히 재귀 깊이를 늘려주지 않으면 시간초과 난다.)

테스트 케이스 | 재귀(런타임, 메모리) | 스택(런타임, 메모리) 
-- | -- | -- 
테스트 1 〉 | 통과 (232.63ms, 44.4MB) | 통과 (277.36ms, 51.2MB)
테스트 2 〉 | 통과 (207.69ms, 44.7MB) | 통과 (239.83ms, 51.6MB)
테스트 3 〉 | 통과 (275.24ms, 44.2MB) | 통과 (281.26ms, 51.2MB)
테스트 4 〉 | 통과 (228.01ms, 44MB) | 통과 (250.90ms, 51MB)
테스트 5 〉 | 통과 (231.30ms, 43.9MB) | 통과 (307.31ms, 50.8MB)
테스트 6 〉 | 통과 (235.94ms, 44.3MB) | 통과 (287.02ms, 51.2MB)
테스트 7 〉 | 통과 (186.35ms, 44.3MB) | 통과 (286.07ms, 52.1MB)
테스트 8 〉 | 통과 (192.58ms, 45.2MB) | 통과 (214.28ms, 51MB)
테스트 9 〉 | 통과 (218.43ms, 52.3MB) | 통과 (281.70ms, 50.7MB)
테스트 10 〉 | 통과 (188.61ms, 44.1MB) | 통과 (306.11ms, 51MB)
테스트 11 〉 | 통과 (92.93ms, 27.1MB) | 통과 (135.91ms, 30.7MB)
테스트 12 〉 | 통과 (54.68ms, 19.8MB) | 통과 (56.04ms, 22.2MB)
테스트 13 〉 | 통과 (12.79ms, 13.4MB) | 통과 (16.10ms, 14MB)
테스트 14 〉 | 통과 (0.01ms, 10.2MB) | 통과 (0.01ms, 10.4MB)
테스트 15 〉 | 통과 (1.07ms, 10.6MB) | 통과 (1.36ms, 10.5MB)
테스트 16 〉 | 통과 (6.06ms, 11.6MB) | 통과 (7.93ms, 12MB)





