### PR TITLE
[2024-09-12] sumin #240

### DIFF
--- a/LeetCode/128/sumin.py
+++ b/LeetCode/128/sumin.py
@@ -1,0 +1,47 @@
+"""
+<문제>
+정렬되지 않은 정수 배열 nums에서 가장 긴 연속하는 원소 배열의 길이를 반환하라.
+알고리즘은 O(n)으로 동작해야 한다.
+
+<제한 사항>
+0 <= nums.length <= 105
+-109 <= nums[i] <= 109
+
+<풀이 시간>
+30분
+
+<풀이>
+파이썬의 정렬 알고리즘인 팀소트는 O(nlogn)이기 때문에 정렬없이 문제를 풀이해야 한다.
+
+0. nums의 길이가 0일 수도 있기 때문에 원소가 없을 때는 0을 return
+1. 중복된 원소 제거 및 빠른 원소 탐색(O(1))을 위해 set 자료형을 사용한다.
+2. num_set의 각 원소를 탐색하며 시작점이 되는 원소인 경우에만 연속한 숫자들을 찾는다. (num-1이 num_set에 없는 경우가 시작점이 되는 경우)
+3. 각 시작점일 때의 최대 길이를 업데이트한다.
+
+<시간복잡도>
+O(n): 각 숫자들을 무조건 한 번씩만 탐색하기 때문에, 최악의 경우 O(n)
+"""
+from typing import List
+
+
+class Solution:
+    def longestConsecutive(self, nums: List[int]) -> int:
+        if not nums:
+            return 0
+
+        num_set = set(nums)
+        max_length = 0
+
+        for num in num_set:
+            # 현재 숫자가 배열의 시작점인 경우만 처리
+            if num - 1 not in num_set:
+                current_num = num
+                current_length = 1
+                # 연속된 숫자가 더 이상 존재하지 않을때까지 찾기
+                while current_num + 1 in num_set:
+                    current_num += 1
+                    current_length += 1
+
+                max_length = max(current_length, max_length)
+
+        return max_length


### PR DESCRIPTION
### PR Summary
<!-- PR 내용을 간략하게 소개해주세요 -->
**<풀이 시간>**
30분

처음에 min(nums)부터 max(nums)까지의 숫자를 모두 순회하면서 확인하려고 했는데, max(nums)의 경우 10억까지 가능하기 때문에 메모리 초과가 났다. 시작점일때부터 그 숫자가 끝날때까지만 확인하는 방식으로 코드를 수정하면 최악의 경우에도 nums의 길이 즉, nums 배열의 각 원소를 한번씩만 확인하기 때문에 O(n)으로 풀이가 가능하다.

문제를 풀고나서 union-find로 풀이하는 방식도 확인했는데 전혀 생각지도 못했다. 좀 더 union-find 문제를 풀어봐야할 것 같다.

<img width="663" alt="image" src="https://github.com/user-attachments/assets/38ca33f5-17e7-45a2-95e7-2abca345f7e0">
