### PR TITLE
[2025-02-25] yerin #417

### DIFF
--- a/Programmers/홀짝트리/yerin.py
+++ b/Programmers/홀짝트리/yerin.py
@@ -1,0 +1,69 @@
+from collections import defaultdict
+
+import sys
+sys.setrecursionlimit(1000000)
+
+
+def generate_graph(edges):
+    graph = defaultdict(list)
+    for n1, n2 in edges:
+        graph[n1].append(n2)
+        graph[n2].append(n1)
+
+    return graph
+
+
+# 트리별로 구분
+def divide_by_group(groups, group_num, cur_node, graph, visited):
+    if len(graph[cur_node]) % 2 == 0:  # 자식 노드 개수: 짝수
+        if cur_node % 2 == 0:  # 현재 노드 정수가 짝수 -> 홀짝
+            groups[group_num][0].append(cur_node)
+        else:  # 역홀짝
+            groups[group_num][1].append(cur_node)
+    else:  # 자식 노드 개수: 홀수
+        if cur_node % 2 == 0:  # 역홀짝
+            groups[group_num][1].append(cur_node)
+        else:  # 홀짝
+            groups[group_num][0].append(cur_node)
+    visited.add(cur_node)
+
+    for nxt_node in graph[cur_node]:
+        if nxt_node in visited:
+            continue
+        divide_by_group(groups, group_num, nxt_node, graph, visited)
+
+    return groups, visited
+
+
+def solution(nodes, edges):
+    answer = [0, 0]
+
+    groups = defaultdict(lambda: [[],[]])  # [홀짝, 역홀짝]
+    visited = set()
+    graph = generate_graph(edges)
+    num = 0
+
+    for node in nodes:
+        if node in visited:
+            continue
+
+        # 자식 노드가 없는 경우 (개수 0)
+        if node not in graph:
+            if node % 2 == 0:  # 홀짝
+                answer[0] += 1
+            else:  # 역홀짝
+                answer[1] += 1
+            continue
+
+        groups, visited = divide_by_group(groups, num, node, graph, visited)
+        num += 1  # 트리 그룹 넘버 갱신
+
+    for g1, g2 in groups.values():
+        # 트리마다 한 개의 노드만이 홀짝 또는 역홀짝일 때, 모든 트리가 같은 성질을 가짐
+        # 노드가 두 개, 각각 홀짝, 역홀짝일 경우 둘 다 루트 노드가 될 수 있음.
+        if len(g1) == 1:
+            answer[0] += 1
+        if len(g2) == 1:
+            answer[1] += 1
+
+    return answer


### PR DESCRIPTION
### PR Summary
<문제 회고>
규칙을 찾는 데 시간이 오래 걸렸다. 나름의 규칙을 찾은 후에는 그냥 생각난 대로 코드를 작성했다. 현재 노드가 루트노드일 때와 아닐 때, 자식 노드 개수가 1 차이난다는 것과 / 루트노드일 때 역홀짝이었던 경우, 루트노드가 아닐 때 홀짝이 되고, 반대의 경우도 동일한 규칙이 적용된다는 걸 알았다. edge 길이가 100만인데, 파이썬은 재귀 깊이가 1000이라 깊이를 늘려주었다. 분기문을 작성할 때, 비슷한 형태의 코드가 많아서 아쉽지만 아이디어가 없어서 그냥 두었다...ㅎ

테스트 | 결과
-- | --
테스트 1 〉 | 통과 (0.46ms, 10.1MB)
테스트 2 〉 | 통과 (0.01ms, 10.3MB)
테스트 3 〉 | 통과 (0.98ms, 10.3MB)
테스트 4 〉 | 통과 (0.74ms, 10.1MB)
테스트 5 〉 | 통과 (1.23ms, 10.4MB)
테스트 6 〉 | 통과 (0.70ms, 10.2MB)
테스트 7 〉 | 통과 (0.67ms, 10.4MB)
테스트 8 〉 | 통과 (0.02ms, 10.1MB)
테스트 9 〉 | 통과 (0.80ms, 10.1MB)
테스트 10 〉 | 통과 (1.06ms, 10.4MB)
테스트 11 〉 | 통과 (0.45ms, 10.3MB)
테스트 12 〉 | 통과 (0.65ms, 10.5MB)
테스트 13 〉 | 통과 (0.20ms, 10.1MB)
테스트 14 〉 | 통과 (0.11ms, 10.2MB)
테스트 15 〉 | 통과 (0.11ms, 10.2MB)
테스트 16 〉 | 통과 (0.11ms, 10.2MB)
테스트 17 〉 | 통과 (0.11ms, 10.2MB)
테스트 18 〉 | 통과 (0.11ms, 10.4MB)
테스트 19 〉 | 통과 (0.12ms, 10.3MB)
테스트 20 〉 | 통과 (0.11ms, 10.2MB)
테스트 21 〉 | 통과 (0.12ms, 10.2MB)
테스트 22 〉 | 통과 (0.11ms, 10.2MB)
테스트 23 〉 | 통과 (0.12ms, 10.2MB)
테스트 24 〉 | 통과 (855.61ms, 119MB)
테스트 25 〉 | 통과 (0.01ms, 10.2MB)
테스트 26 〉 | 통과 (784.58ms, 118MB)
테스트 27 〉 | 통과 (813.90ms, 119MB)
테스트 28 〉 | 통과 (526.57ms, 91.1MB)
테스트 29 〉 | 통과 (511.36ms, 91.3MB)
테스트 30 〉 | 통과 (0.01ms, 10.1MB)
테스트 31 〉 | 통과 (443.61ms, 90.8MB)
테스트 32 〉 | 통과 (0.01ms, 10.3MB)
테스트 33 〉 | 통과 (1077.38ms, 119MB)
테스트 34 〉 | 통과 (1060.28ms, 119MB)
테스트 35 〉 | 통과 (563.88ms, 90.9MB)
테스트 36 〉 | 통과 (883.92ms, 120MB)
테스트 37 〉 | 통과 (883.75ms, 120MB)
테스트 38 〉 | 통과 (710.44ms, 120MB)
테스트 39 〉 | 통과 (946.53ms, 120MB)
테스트 40 〉 | 통과 (928.76ms, 120MB)
테스트 41 〉 | 통과 (1043.20ms, 120MB)
테스트 42 〉 | 통과 (1104.99ms, 161MB)
테스트 43 〉 | 통과 (965.84ms, 150MB)
테스트 44 〉 | 통과 (866.03ms, 149MB)
테스트 45 〉 | 통과 (961.65ms, 120MB)
테스트 46 〉 | 통과 (871.49ms, 121MB)
테스트 47 〉 | 통과 (923.20ms, 120MB)
테스트 48 〉 | 통과 (1032.66ms, 120MB)
테스트 49 〉 | 통과 (1055.81ms, 162MB)
테스트 50 〉 | 통과 (943.78ms, 150MB)
테스트 51 〉 | 통과 (960.55ms, 148MB)
테스트 52 〉 | 통과 (981.55ms, 164MB)
테스트 53 〉 | 통과 (827.16ms, 148MB)
테스트 54 〉 | 통과 (871.06ms, 156MB)

